### PR TITLE
[US-002] Set Up GitHub Actions CI/CD

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,14 @@
 {
   "permissions": {
     "allow": [
-      "WebSearch"
+      "WebSearch",
+      "Bash(gh label create:*)",
+      "Bash(gh issue create:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(gh issue close:*)"
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.app
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app || sudo xcode-select -s /Applications/Xcode_16.1.app || sudo xcode-select -s /Applications/Xcode_16.app || sudo xcode-select -s /Applications/Xcode.app
 
       - name: Show Xcode version
         run: xcodebuild -version
@@ -30,16 +30,28 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.app
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app || sudo xcode-select -s /Applications/Xcode_16.1.app || sudo xcode-select -s /Applications/Xcode_16.app || sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Check for test target
+        id: check-tests
+        run: |
+          cd QuickSnip
+          if xcodebuild -list -json | grep -q "QuickSnipTests"; then
+            echo "has_tests=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_tests=false" >> $GITHUB_OUTPUT
+            echo "No test target found, skipping tests"
+          fi
 
       - name: Run Tests
+        if: steps.check-tests.outputs.has_tests == 'true'
         run: |
           cd QuickSnip
           xcodebuild test -scheme QuickSnip -destination 'platform=macOS' -resultBundlePath TestResults
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.check-tests.outputs.has_tests == 'true' && always()
         with:
           name: test-results
           path: QuickSnip/TestResults

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.app
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app || sudo xcode-select -s /Applications/Xcode_16.1.app || sudo xcode-select -s /Applications/Xcode_16.app || sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Show Xcode version
+        run: xcodebuild -version
 
       - name: Build Release
         run: |
           cd QuickSnip
-          xcodebuild -scheme QuickSnip -configuration Release -archivePath build/QuickSnip.xcarchive archive
+          xcodebuild -scheme QuickSnip -configuration Release -archivePath build/QuickSnip.xcarchive archive CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO
 
       - name: Export App
         run: |
           cd QuickSnip
-          xcodebuild -exportArchive -archivePath build/QuickSnip.xcarchive -exportPath build/export -exportOptionsPlist ExportOptions.plist
+          mkdir -p build/export
+          cp -R build/QuickSnip.xcarchive/Products/Applications/QuickSnip.app build/export/
 
       - name: Create DMG
         run: |
@@ -34,3 +38,11 @@ jobs:
         with:
           name: QuickSnip-${{ github.ref_name }}
           path: QuickSnip/build/export/QuickSnip.dmg
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: QuickSnip/build/export/QuickSnip.dmg
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Refined GitHub Actions workflows for CI/CD:

- **CI workflow** (`.github/workflows/ci.yml`): Build on push, test on PR
- **Release workflow** (`.github/workflows/release.yml`): Build and release on tag

## Changes

- Add fallback Xcode version selection for runner compatibility
- Add conditional test execution (skips if no test target exists yet)
- Simplify release export without ExportOptions.plist requirement
- Add automatic GitHub Release creation with DMG on tag push
- Disable code signing for CI builds (ad-hoc signing)

## Acceptance Criteria

- [x] Build workflow on push to any branch
- [x] Test workflow on pull request (conditional)
- [x] Release workflow on tag push
- [x] macOS runner with Xcode 16

## Test Plan

- [x] CI will run on this PR push
- [ ] Verify build job succeeds
- [ ] Verify test job handles missing test target gracefully

Closes #2