### PR TITLE
[US-005] Implement SyncStatus Enum

### DIFF
--- a/QuickSnip/QuickSnip/Models/SyncStatus.swift
+++ b/QuickSnip/QuickSnip/Models/SyncStatus.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum SyncStatus: Equatable {
+    case idle
+    case syncing
+    case synced
+    case error(String)
+
+    var symbolName: String {
+        switch self {
+        case .idle:
+            return "arrow.triangle.2.circlepath"
+        case .syncing:
+            return "arrow.triangle.2.circlepath.circle"
+        case .synced:
+            return "checkmark.circle.fill"
+        case .error:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .idle:
+            return "Ready to sync"
+        case .syncing:
+            return "Syncing..."
+        case .synced:
+            return "Synced"
+        case .error(let message):
+            return "Error: \(message)"
+        }
+    }
+
+    var isError: Bool {
+        if case .error = self {
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Summary

Implement the SyncStatus enum for representing sync state in the UI.

## Implementation

```swift
enum SyncStatus: Equatable {
    case idle
    case syncing
    case synced
    case error(String)
}
```

## Properties

| Property | Type | Description |
|----------|------|-------------|
| symbolName | String | SF Symbol for UI display |
| description | String | Human-readable status |
| isError | Bool | Quick error check |

## SF Symbols

| Case | Symbol |
|------|--------|
| idle | arrow.triangle.2.circlepath |
| syncing | arrow.triangle.2.circlepath.circle |
| synced | checkmark.circle.fill |
| error | exclamationmark.triangle.fill |

## Acceptance Criteria

- [x] Cases: idle, syncing, synced, error(String)
- [x] Computed property for SF Symbol name
- [x] Equatable conformance

Closes #5