### PR TITLE
[US-006] Implement MarkdownParser

### DIFF
--- a/QuickSnip/QuickSnip/Models/Snippet.swift
+++ b/QuickSnip/QuickSnip/Models/Snippet.swift
@@ -36,12 +36,7 @@ struct Snippet: Identifiable, Codable, Hashable {
             return nil
         }
 
-        guard let data = try? Data(contentsOf: fileURL),
-              let fileContent = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-
-        guard let parsed = Self.parseFrontmatter(fileContent) else {
+        guard let parsed = MarkdownParser.parse(fileAt: fileURL) else {
             return nil
         }
 
@@ -55,59 +50,5 @@ struct Snippet: Identifiable, Codable, Hashable {
         self.enabled = parsed.enabled
         self.filePath = fileURL
         self.lastModified = modDate
-    }
-
-    private static func parseFrontmatter(_ text: String) -> (shortcut: String, content: String, category: String?, enabled: Bool)? {
-        let delimiter = "---"
-        let lines = text.components(separatedBy: .newlines)
-
-        guard lines.first == delimiter else {
-            return nil
-        }
-
-        var endIndex: Int?
-        for (index, line) in lines.dropFirst().enumerated() {
-            if line == delimiter {
-                endIndex = index + 1
-                break
-            }
-        }
-
-        guard let end = endIndex else {
-            return nil
-        }
-
-        let frontmatterLines = Array(lines[1..<end])
-        let contentLines = Array(lines[(end + 1)...])
-        let content = contentLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-
-        var shortcut: String?
-        var category: String?
-        var enabled = true
-
-        for line in frontmatterLines {
-            let parts = line.split(separator: ":", maxSplits: 1)
-            guard parts.count == 2 else { continue }
-
-            let key = parts[0].trimmingCharacters(in: .whitespaces).lowercased()
-            let value = parts[1].trimmingCharacters(in: .whitespaces)
-
-            switch key {
-            case "shortcut":
-                shortcut = value
-            case "category":
-                category = value.isEmpty ? nil : value
-            case "enabled":
-                enabled = value.lowercased() != "false"
-            default:
-                break
-            }
-        }
-
-        guard let sc = shortcut, !sc.isEmpty else {
-            return nil
-        }
-
-        return (sc, content, category, enabled)
     }
 }

--- a/QuickSnip/QuickSnip/Services/MarkdownParser.swift
+++ b/QuickSnip/QuickSnip/Services/MarkdownParser.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+struct MarkdownParser {
+    struct ParsedSnippet {
+        let shortcut: String
+        let content: String
+        let category: String?
+        let enabled: Bool
+    }
+
+    static func parse(_ text: String) -> ParsedSnippet? {
+        let delimiter = "---"
+        let lines = text.components(separatedBy: .newlines)
+
+        guard lines.first == delimiter else {
+            return nil
+        }
+
+        var endIndex: Int?
+        for (index, line) in lines.dropFirst().enumerated() {
+            if line == delimiter {
+                endIndex = index + 1
+                break
+            }
+        }
+
+        guard let end = endIndex else {
+            return nil
+        }
+
+        let frontmatterLines = Array(lines[1..<end])
+        let contentLines = Array(lines[(end + 1)...])
+        let content = contentLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var shortcut: String?
+        var category: String?
+        var enabled = true
+
+        for line in frontmatterLines {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+
+            let key = parts[0].trimmingCharacters(in: .whitespaces).lowercased()
+            let value = parts[1].trimmingCharacters(in: .whitespaces)
+
+            switch key {
+            case "shortcut":
+                shortcut = value
+            case "category":
+                category = value.isEmpty ? nil : value
+            case "enabled":
+                enabled = value.lowercased() != "false"
+            default:
+                break
+            }
+        }
+
+        guard let sc = shortcut, !sc.isEmpty else {
+            return nil
+        }
+
+        return ParsedSnippet(shortcut: sc, content: content, category: category, enabled: enabled)
+    }
+
+    static func parse(fileAt url: URL) -> ParsedSnippet? {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return parse(text)
+    }
+
+    static func generateMarkdown(shortcut: String, content: String, category: String? = nil, enabled: Bool = true) -> String {
+        var frontmatter = "---\n"
+        frontmatter += "shortcut: \(shortcut)\n"
+        if let category = category {
+            frontmatter += "category: \(category)\n"
+        }
+        if !enabled {
+            frontmatter += "enabled: false\n"
+        }
+        frontmatter += "---\n"
+        return frontmatter + content
+    }
+}


### PR DESCRIPTION
## Summary

Implement dedicated MarkdownParser service for YAML frontmatter parsing.

## Implementation

```swift
struct MarkdownParser {
    struct ParsedSnippet {
        let shortcut: String
        let content: String
        let category: String?
        let enabled: Bool
    }

    static func parse(_ text: String) -> ParsedSnippet?
    static func parse(fileAt url: URL) -> ParsedSnippet?
    static func generateMarkdown(...) -> String
}
```

## Features

- Parse `---` delimited YAML frontmatter
- Extract shortcut (required), category (optional), enabled (default true)
- Return content after frontmatter
- Handle malformed files gracefully (returns nil)
- Generate markdown from snippet data

## Refactoring

- Moved parsing logic from Snippet model to MarkdownParser service
- Snippet now uses MarkdownParser for file initialization
- Better separation of concerns

## Acceptance Criteria

- [x] Parse `---` delimited frontmatter
- [x] Extract shortcut (required), category (optional), enabled (default true)
- [x] Return content after frontmatter
- [x] Handle malformed files gracefully

Closes #6