### PR TITLE
[US-011] Implement VariableService

### DIFF
--- a/QuickSnip/QuickSnip/Services/VariableService.swift
+++ b/QuickSnip/QuickSnip/Services/VariableService.swift
@@ -1,0 +1,43 @@
+import Foundation
+import AppKit
+
+struct VariableService {
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    static func expand(_ content: String) -> String {
+        var result = content
+
+        result = result.replacingOccurrences(
+            of: "{date}",
+            with: dateFormatter.string(from: Date())
+        )
+
+        result = result.replacingOccurrences(
+            of: "{time}",
+            with: timeFormatter.string(from: Date())
+        )
+
+        result = result.replacingOccurrences(
+            of: "{clipboard}",
+            with: clipboardContent()
+        )
+
+        return result
+    }
+
+    private static func clipboardContent() -> String {
+        NSPasteboard.general.string(forType: .string) ?? ""
+    }
+}


### PR DESCRIPTION
## Summary

- Add VariableService with `expand(_ content: String) -> String` function
- Expand `{date}` to formatted date (medium style)
- Expand `{time}` to formatted time (short style)
- Expand `{clipboard}` to current pasteboard contents
- Unknown variables are left unchanged in the output

Closes #11