### PR TITLE
[US-014] Implement SettingsViewModel

### DIFF
--- a/QuickSnip/QuickSnip/ViewModels/SettingsViewModel.swift
+++ b/QuickSnip/QuickSnip/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import ServiceManagement
+import Observation
+
+@MainActor
+@Observable
+final class SettingsViewModel {
+    var launchAtLogin: Bool {
+        didSet {
+            updateLaunchAtLogin()
+            UserDefaults.standard.set(launchAtLogin, forKey: Keys.launchAtLogin)
+        }
+    }
+
+    var autoSync: Bool {
+        didSet {
+            UserDefaults.standard.set(autoSync, forKey: Keys.autoSync)
+        }
+    }
+
+    var snippetsDirectory: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".snippets", isDirectory: true)
+    }
+
+    private enum Keys {
+        static let launchAtLogin = "launchAtLogin"
+        static let autoSync = "autoSync"
+    }
+
+    init() {
+        self.launchAtLogin = UserDefaults.standard.bool(forKey: Keys.launchAtLogin)
+        self.autoSync = UserDefaults.standard.bool(forKey: Keys.autoSync)
+
+        syncLaunchAtLoginState()
+    }
+
+    private func syncLaunchAtLoginState() {
+        let currentStatus = SMAppService.mainApp.status
+        let isEnabled = currentStatus == .enabled
+
+        if launchAtLogin != isEnabled {
+            launchAtLogin = isEnabled
+        }
+    }
+
+    private func updateLaunchAtLogin() {
+        do {
+            if launchAtLogin {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            syncLaunchAtLoginState()
+        }
+    }
+
+    func resetToDefaults() {
+        launchAtLogin = false
+        autoSync = false
+    }
+}


### PR DESCRIPTION
## Summary

- Add SettingsViewModel with @Observable for settings state management
- Launch at login toggle using SMAppService (macOS native)
- Auto-sync toggle for automatic Text Replacement synchronization
- UserDefaults persistence for all settings
- Automatic state sync with system launch agent status

Closes #14