### PR TITLE
[US-020] Implement SnippetPreviewView

### DIFF
--- a/QuickSnip/QuickSnip/Views/SnippetPreviewView.swift
+++ b/QuickSnip/QuickSnip/Views/SnippetPreviewView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+struct SnippetPreviewView: View {
+    let snippet: Snippet
+    var onCopy: ((Snippet) -> Void)?
+    var onEdit: ((Snippet) -> Void)?
+    var onDismiss: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            headerView
+
+            Divider()
+
+            contentView
+
+            if snippet.category != nil {
+                categoryView
+            }
+
+            Divider()
+
+            actionButtons
+        }
+        .padding()
+        .frame(width: 320)
+    }
+
+    private var headerView: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(snippet.fileName)
+                    .font(.headline)
+
+                if !snippet.enabled {
+                    Label("Disabled", systemImage: "pause.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            Text(snippet.shortcut)
+                .font(.system(.caption, design: .monospaced))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.quaternary)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+    }
+
+    private var contentView: some View {
+        ScrollView {
+            Text(snippet.content)
+                .font(.body)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxHeight: 200)
+    }
+
+    @ViewBuilder
+    private var categoryView: some View {
+        if let category = snippet.category {
+            HStack {
+                Image(systemName: "tag")
+                    .font(.caption)
+                Text(category)
+                    .font(.caption)
+            }
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack {
+            if let onCopy = onCopy {
+                Button {
+                    onCopy(snippet)
+                    onDismiss?()
+                } label: {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+            if let onEdit = onEdit {
+                Button {
+                    onEdit(snippet)
+                    onDismiss?()
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Spacer()
+
+            Text(snippet.lastModified, style: .relative)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+#Preview {
+    SnippetPreviewView(
+        snippet: Snippet(
+            shortcut: ";sig",
+            content: "Best regards,\nPascal\n\nSenior Developer\nExample Corp",
+            category: "work",
+            filePath: URL(fileURLWithPath: "/tmp/sig.md")
+        ),
+        onCopy: { _ in },
+        onEdit: { _ in },
+        onDismiss: { }
+    )
+}

--- a/QuickSnip/QuickSnip/Views/SnippetRowView.swift
+++ b/QuickSnip/QuickSnip/Views/SnippetRowView.swift
@@ -45,7 +45,12 @@ struct SnippetRowView: View {
             showingPreview = true
         }
         .popover(isPresented: $showingPreview, arrowEdge: .trailing) {
-            SnippetPreviewPopover(snippet: snippet)
+            SnippetPreviewView(
+                snippet: snippet,
+                onCopy: onCopy,
+                onEdit: onEdit,
+                onDismiss: { showingPreview = false }
+            )
         }
     }
 
@@ -79,48 +84,6 @@ struct SnippetRowView: View {
                 .help("Edit snippet")
             }
         }
-    }
-}
-
-private struct SnippetPreviewPopover: View {
-    let snippet: Snippet
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(snippet.fileName)
-                    .font(.headline)
-                Spacer()
-                Text(snippet.shortcut)
-                    .font(.caption)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.quaternary)
-                    .clipShape(Capsule())
-            }
-
-            Divider()
-
-            ScrollView {
-                Text(snippet.content)
-                    .font(.body)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxHeight: 200)
-
-            if let category = snippet.category {
-                HStack {
-                    Image(systemName: "tag")
-                        .font(.caption)
-                    Text(category)
-                        .font(.caption)
-                }
-                .foregroundStyle(.secondary)
-            }
-        }
-        .padding()
-        .frame(width: 300)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add dedicated SnippetPreviewView component for long-press preview
- Full snippet content with scrollable view
- Shortcut badge with monospaced font
- Enabled/disabled status indicator
- Copy and Edit action buttons
- Category tag display
- Last modified relative timestamp
- Dismiss callback for proper popover control
- Popover dismisses on click outside (native behavior)

Closes #20