### PR TITLE
[REFACTOR] Add service protocols for dependency injection

### DIFF
--- a/QuickSnip/QuickSnip/Protocols/ServiceProtocols.swift
+++ b/QuickSnip/QuickSnip/Protocols/ServiceProtocols.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+// MARK: - File Service Protocol
+
+protocol SnippetFileServiceProtocol: Sendable {
+    var snippetsDirectory: URL { get }
+
+    func loadSnippetTree() throws -> SnippetFolder
+    func createSnippet(named name: String, shortcut: String, in folder: SnippetFolder) throws -> Snippet
+    func createFolder(named name: String, in parent: SnippetFolder) throws -> SnippetFolder
+    func deleteSnippet(_ snippet: Snippet) throws
+    func deleteFolder(_ folder: SnippetFolder) throws
+}
+
+// MARK: - Text Replacement Protocol
+
+protocol TextReplacementServiceProtocol: Sendable {
+    var hasAccess: Bool { get }
+
+    func syncSnippets(_ snippets: [Snippet]) throws -> SyncResult
+    func getCurrentReplacements() throws -> [TextReplacement]
+    func openFullDiskAccessSettings()
+}
+
+// MARK: - Notification Protocol
+
+@MainActor
+protocol NotificationServiceProtocol {
+    func requestAuthorization()
+    func showSuccess(title: String, message: String)
+    func showError(title: String, message: String)
+}
+
+// MARK: - File Watcher Protocol
+
+@MainActor
+protocol FileWatcherServiceProtocol: AnyObject {
+    var isRunning: Bool { get }
+
+    func start()
+    func stop()
+}

--- a/QuickSnip/QuickSnip/Services/FileWatcherService.swift
+++ b/QuickSnip/QuickSnip/Services/FileWatcherService.swift
@@ -6,7 +6,7 @@ protocol FileWatcherDelegate: AnyObject {
 }
 
 @MainActor
-final class FileWatcherService {
+final class FileWatcherService: FileWatcherServiceProtocol {
     weak var delegate: FileWatcherDelegate?
 
     private let path: String
@@ -14,7 +14,7 @@ final class FileWatcherService {
     private nonisolated(unsafe) var eventStream: FSEventStreamRef?
     private var debounceTask: Task<Void, Never>?
 
-    private var isRunning = false
+    var isRunning: Bool { eventStream != nil }
 
     init(path: String, debounceInterval: TimeInterval = 0.5) {
         self.path = path
@@ -34,7 +34,7 @@ final class FileWatcherService {
     }
 
     func start() {
-        guard !isRunning else { return }
+        guard eventStream == nil else { return }
 
         let pathsToWatch = [path] as CFArray
 
@@ -73,11 +73,10 @@ final class FileWatcherService {
         eventStream = stream
         FSEventStreamSetDispatchQueue(stream, DispatchQueue.main)
         FSEventStreamStart(stream)
-        isRunning = true
     }
 
     func stop() {
-        guard isRunning, let stream = eventStream else { return }
+        guard let stream = eventStream else { return }
 
         debounceTask?.cancel()
         debounceTask = nil
@@ -86,7 +85,6 @@ final class FileWatcherService {
         FSEventStreamInvalidate(stream)
         FSEventStreamRelease(stream)
         eventStream = nil
-        isRunning = false
     }
 
     private func handleEvent() {

--- a/QuickSnip/QuickSnip/Services/NotificationService.swift
+++ b/QuickSnip/QuickSnip/Services/NotificationService.swift
@@ -2,49 +2,57 @@ import Foundation
 import UserNotifications
 
 @MainActor
-final class NotificationService {
+final class NotificationService: NotificationServiceProtocol {
     static let shared = NotificationService()
 
-    private init() {}
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
 
     func requestAuthorization() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
     }
 
-    func showSyncSuccess(count: Int) {
-        let content = UNMutableNotificationContent()
-        content.title = "Sync Complete"
-        content.body = "Synced \(count) snippet\(count == 1 ? "" : "s") to Text Replacement"
-        content.sound = .default
-
-        scheduleNotification(content: content, identifier: "sync-success")
-    }
-
-    func showImportSuccess(count: Int) {
-        let content = UNMutableNotificationContent()
-        content.title = "Import Complete"
-        content.body = "Imported \(count) snippet\(count == 1 ? "" : "s")"
-        content.sound = .default
-
-        scheduleNotification(content: content, identifier: "import-success")
+    func showSuccess(title: String, message: String) {
+        show(title: title, body: message, isCritical: false)
     }
 
     func showError(title: String, message: String) {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = message
-        content.sound = .defaultCritical
-
-        scheduleNotification(content: content, identifier: "error-\(UUID().uuidString)")
+        show(title: title, body: message, isCritical: true)
     }
 
-    private func scheduleNotification(content: UNMutableNotificationContent, identifier: String) {
+    // MARK: - Convenience Methods
+
+    func showSyncSuccess(count: Int) {
+        showSuccess(
+            title: "Sync Complete",
+            message: "Synced \(count) snippet\(count == 1 ? "" : "s") to Text Replacement"
+        )
+    }
+
+    func showImportSuccess(count: Int) {
+        showSuccess(
+            title: "Import Complete",
+            message: "Imported \(count) snippet\(count == 1 ? "" : "s")"
+        )
+    }
+
+    // MARK: - Private
+
+    private func show(title: String, body: String, isCritical: Bool) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = isCritical ? .defaultCritical : .default
+
         let request = UNNotificationRequest(
-            identifier: identifier,
+            identifier: UUID().uuidString,
             content: content,
             trigger: nil
         )
 
-        UNUserNotificationCenter.current().add(request)
+        center.add(request)
     }
 }

--- a/QuickSnip/QuickSnip/Services/SnippetFileService.swift
+++ b/QuickSnip/QuickSnip/Services/SnippetFileService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SnippetFileService: Sendable {
+struct SnippetFileService: SnippetFileServiceProtocol {
     let snippetsDirectory: URL
 
     private var fileManager: FileManager { FileManager.default }

--- a/QuickSnip/QuickSnip/Services/TextReplacementService.swift
+++ b/QuickSnip/QuickSnip/Services/TextReplacementService.swift
@@ -6,7 +6,7 @@ struct TextReplacement: Equatable {
     let phrase: String
 }
 
-struct TextReplacementService: Sendable {
+struct TextReplacementService: TextReplacementServiceProtocol {
     static let databaseURL: URL = {
         let home = FileManager.default.homeDirectoryForCurrentUser
         return home


### PR DESCRIPTION
## Summary
- Create ServiceProtocols.swift with protocol definitions for all services
- Enable dependency injection and testability
- Simplify NotificationService with injectable center and generic show() method
- Make FileWatcherService.isRunning a computed property (removes redundant state)

## Protocols Added
- `SnippetFileServiceProtocol`
- `TextReplacementServiceProtocol`
- `NotificationServiceProtocol`
- `FileWatcherServiceProtocol`

Closes #50