### PR TITLE
[REFACTOR] Purify Snippet model (#51)

### DIFF
--- a/QuickSnip/QuickSnip/Models/Snippet.swift
+++ b/QuickSnip/QuickSnip/Models/Snippet.swift
@@ -30,25 +30,4 @@ struct Snippet: Identifiable, Codable, Hashable {
         self.filePath = filePath
         self.lastModified = lastModified
     }
-
-    init?(from fileURL: URL) {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return nil
-        }
-
-        guard let parsed = MarkdownParser.parse(fileAt: fileURL) else {
-            return nil
-        }
-
-        let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
-        let modDate = attributes?[.modificationDate] as? Date ?? Date()
-
-        self.id = UUID()
-        self.shortcut = parsed.shortcut
-        self.content = parsed.content
-        self.category = parsed.category
-        self.enabled = parsed.enabled
-        self.filePath = fileURL
-        self.lastModified = modDate
-    }
 }

--- a/QuickSnip/QuickSnip/Protocols/ServiceProtocols.swift
+++ b/QuickSnip/QuickSnip/Protocols/ServiceProtocols.swift
@@ -10,6 +10,7 @@ protocol SnippetFileServiceProtocol: Sendable {
     func createFolder(named name: String, in parent: SnippetFolder) throws -> SnippetFolder
     func deleteSnippet(_ snippet: Snippet) throws
     func deleteFolder(_ folder: SnippetFolder) throws
+    func snippetFromFile(_ fileURL: URL) -> Snippet?
 }
 
 // MARK: - Text Replacement Protocol

--- a/QuickSnip/QuickSnip/Services/SnippetFileService.swift
+++ b/QuickSnip/QuickSnip/Services/SnippetFileService.swift
@@ -39,7 +39,7 @@ struct SnippetFileService: SnippetFileServiceProtocol {
                 let subfolder = try loadFolder(at: item, parent: nil)
                 subfolders.append(subfolder)
             } else if item.pathExtension == "md" {
-                if let snippet = Snippet(from: item) {
+                if let snippet = snippetFromFile(item) {
                     snippets.append(snippet)
                 }
             }
@@ -74,7 +74,7 @@ struct SnippetFileService: SnippetFileServiceProtocol {
 
         try content.write(to: fileURL, atomically: true, encoding: .utf8)
 
-        guard let snippet = Snippet(from: fileURL) else {
+        guard let snippet = snippetFromFile(fileURL) else {
             throw SnippetFileError.failedToCreateSnippet
         }
 
@@ -110,6 +110,23 @@ struct SnippetFileService: SnippetFileServiceProtocol {
             enabled: snippet.enabled
         )
         try content.write(to: snippet.filePath, atomically: true, encoding: .utf8)
+    }
+
+    func snippetFromFile(_ fileURL: URL) -> Snippet? {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
+        guard let parsed = MarkdownParser.parse(fileAt: fileURL) else { return nil }
+
+        let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path)
+        let modDate = attributes?[.modificationDate] as? Date ?? Date()
+
+        return Snippet(
+            shortcut: parsed.shortcut,
+            content: parsed.content,
+            category: parsed.category,
+            enabled: parsed.enabled,
+            filePath: fileURL,
+            lastModified: modDate
+        )
     }
 
     private func sanitizeFileName(_ name: String) -> String {


### PR DESCRIPTION
## Summary
- Remove `init?(from fileURL:)` failable initializer from Snippet struct
- Add `snippetFromFile()` factory method to SnippetFileService
- Update protocol to include new factory method
- Snippet is now a pure data structure with no parsing logic

This makes Snippet a clean data model without file system dependencies.

## Test plan
- [ ] Build succeeds
- [ ] App launches and displays snippets
- [ ] Creating new snippets works
- [ ] Snippets load correctly from disk

Closes #51