### PR TITLE
[REFACTOR] Convert SnippetFolder to pure struct (#52)

### DIFF
--- a/QuickSnip/QuickSnip/Models/SnippetFolder.swift
+++ b/QuickSnip/QuickSnip/Models/SnippetFolder.swift
@@ -1,63 +1,37 @@
 import Foundation
-import SwiftUI
 
-@Observable
-final class SnippetFolder: Identifiable, Hashable {
+struct SnippetFolder: Identifiable, Hashable {
     let id: UUID
-    var name: String
+    let name: String
     let path: URL
-    var children: [SnippetFolder]
-    var snippets: [Snippet]
-    var isExpanded: Bool
-    weak var parent: SnippetFolder?
-
-    var allSnippets: [Snippet] {
-        var result = snippets
-        for child in children {
-            result.append(contentsOf: child.allSnippets)
-        }
-        return result
-    }
-
-    var allFolders: [SnippetFolder] {
-        var result = [self]
-        for child in children {
-            result.append(contentsOf: child.allFolders)
-        }
-        return result
-    }
-
-    var snippetCount: Int {
-        allSnippets.count
-    }
+    let children: [SnippetFolder]
+    let snippets: [Snippet]
 
     init(
         id: UUID = UUID(),
         name: String,
         path: URL,
         children: [SnippetFolder] = [],
-        snippets: [Snippet] = [],
-        isExpanded: Bool = false,
-        parent: SnippetFolder? = nil
+        snippets: [Snippet] = []
     ) {
         self.id = id
         self.name = name
         self.path = path
         self.children = children
         self.snippets = snippets
-        self.isExpanded = isExpanded
-        self.parent = parent
+    }
+}
 
-        for child in self.children {
-            child.parent = self
-        }
+extension SnippetFolder {
+    var allSnippets: [Snippet] {
+        snippets + children.flatMap(\.allSnippets)
     }
 
-    static func == (lhs: SnippetFolder, rhs: SnippetFolder) -> Bool {
-        lhs.id == rhs.id
+    var allFolders: [SnippetFolder] {
+        [self] + children.flatMap(\.allFolders)
     }
 
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
+    var snippetCount: Int {
+        allSnippets.count
     }
 }

--- a/QuickSnip/QuickSnip/Services/SnippetFileService.swift
+++ b/QuickSnip/QuickSnip/Services/SnippetFileService.swift
@@ -18,10 +18,10 @@ struct SnippetFileService: SnippetFileServiceProtocol {
 
     func loadSnippetTree() throws -> SnippetFolder {
         try ensureSnippetsDirectoryExists()
-        return try loadFolder(at: snippetsDirectory, parent: nil)
+        return try loadFolder(at: snippetsDirectory)
     }
 
-    private func loadFolder(at url: URL, parent: SnippetFolder?) throws -> SnippetFolder {
+    private func loadFolder(at url: URL) throws -> SnippetFolder {
         let contents = try fileManager.contentsOfDirectory(
             at: url,
             includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
@@ -36,7 +36,7 @@ struct SnippetFileService: SnippetFileServiceProtocol {
             let isDirectory = resourceValues.isDirectory ?? false
 
             if isDirectory {
-                let subfolder = try loadFolder(at: item, parent: nil)
+                let subfolder = try loadFolder(at: item)
                 subfolders.append(subfolder)
             } else if item.pathExtension == "md" {
                 if let snippet = snippetFromFile(item) {
@@ -48,19 +48,12 @@ struct SnippetFileService: SnippetFileServiceProtocol {
         subfolders.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         snippets.sort { $0.fileName.localizedCaseInsensitiveCompare($1.fileName) == .orderedAscending }
 
-        let folder = SnippetFolder(
+        return SnippetFolder(
             name: url.lastPathComponent,
             path: url,
             children: subfolders,
-            snippets: snippets,
-            parent: parent
+            snippets: snippets
         )
-
-        for subfolder in folder.children {
-            subfolder.parent = folder
-        }
-
-        return folder
     }
 
     func createSnippet(named name: String, shortcut: String, in folder: SnippetFolder) throws -> Snippet {
@@ -89,8 +82,7 @@ struct SnippetFileService: SnippetFileServiceProtocol {
 
         return SnippetFolder(
             name: folderName,
-            path: folderURL,
-            parent: parent
+            path: folderURL
         )
     }
 

--- a/QuickSnip/QuickSnip/ViewModels/SnippetTreeViewModel.swift
+++ b/QuickSnip/QuickSnip/ViewModels/SnippetTreeViewModel.swift
@@ -9,6 +9,7 @@ final class SnippetTreeViewModel: FileWatcherDelegate {
     var syncStatus: SyncStatus = .idle
     var searchText: String = ""
     var errorMessage: String?
+    var expandedFolderIDs: Set<UUID> = []
 
     private let fileService = SnippetFileService()
     private let textReplacementService = TextReplacementService()
@@ -119,6 +120,18 @@ final class SnippetTreeViewModel: FileWatcherDelegate {
         loadSnippets()
     }
 
+    func isExpanded(_ folder: SnippetFolder) -> Bool {
+        expandedFolderIDs.contains(folder.id)
+    }
+
+    func toggleExpanded(_ folder: SnippetFolder) {
+        if expandedFolderIDs.contains(folder.id) {
+            expandedFolderIDs.remove(folder.id)
+        } else {
+            expandedFolderIDs.insert(folder.id)
+        }
+    }
+
     private func setupFileWatcher() {
         fileWatcher = FileWatcherService(url: fileService.snippetsDirectory)
         fileWatcher?.delegate = self
@@ -147,9 +160,7 @@ final class SnippetTreeViewModel: FileWatcherDelegate {
             name: folder.name,
             path: folder.path,
             children: matchingChildren,
-            snippets: matchingSnippets,
-            isExpanded: true,
-            parent: folder.parent
+            snippets: matchingSnippets
         )
     }
 }

--- a/QuickSnip/QuickSnip/Views/FolderRowView.swift
+++ b/QuickSnip/QuickSnip/Views/FolderRowView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 
 struct FolderRowView: View {
     let folder: SnippetFolder
-    @Binding var isExpanded: Bool
+    let isExpanded: Bool
+    let onToggle: () -> Void
 
     var body: some View {
         Button {
             withAnimation(.easeInOut(duration: 0.2)) {
-                isExpanded.toggle()
+                onToggle()
             }
         } label: {
             HStack(spacing: 6) {
@@ -54,7 +55,8 @@ struct FolderRowView: View {
                     Snippet(shortcut: ";sig", content: "Best regards", filePath: URL(fileURLWithPath: "/tmp/sig.md"))
                 ]
             ),
-            isExpanded: .constant(true)
+            isExpanded: true,
+            onToggle: {}
         )
 
         FolderRowView(
@@ -65,7 +67,8 @@ struct FolderRowView: View {
                     Snippet(shortcut: ";addr", content: "123 Main St", filePath: URL(fileURLWithPath: "/tmp/addr.md"))
                 ]
             ),
-            isExpanded: .constant(false)
+            isExpanded: false,
+            onToggle: {}
         )
     }
     .frame(width: 320)

--- a/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
+++ b/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
@@ -183,6 +183,7 @@ struct MenuBarContentView: View {
             if let root = viewModel.filteredRootFolder {
                 SnippetTreeView(
                     folder: root,
+                    viewModel: viewModel,
                     onSnippetCopy: { snippet in
                         viewModel.copyToClipboard(snippet)
                     },
@@ -323,7 +324,7 @@ private struct NewFolderSheet: View {
 struct SnippetExportDocument: FileDocument {
     static var readableContentTypes: [UTType] { [.zip] }
 
-    nonisolated(unsafe) let folder: SnippetFolder?
+    let folder: SnippetFolder?
 
     init(folder: SnippetFolder?) {
         self.folder = folder

--- a/QuickSnip/QuickSnip/Views/SnippetTreeView.swift
+++ b/QuickSnip/QuickSnip/Views/SnippetTreeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SnippetTreeView: View {
     let folder: SnippetFolder
+    @Bindable var viewModel: SnippetTreeViewModel
     let onSnippetCopy: (Snippet) -> Void
     var onSnippetEdit: ((Snippet) -> Void)?
 
@@ -18,8 +19,10 @@ struct SnippetTreeView: View {
                 ForEach(folder.children) { childFolder in
                     FolderSection(
                         folder: childFolder,
+                        viewModel: viewModel,
                         onSnippetCopy: onSnippetCopy,
-                        onSnippetEdit: onSnippetEdit
+                        onSnippetEdit: onSnippetEdit,
+                        forceExpanded: !viewModel.searchText.isEmpty
                     )
                 }
             }
@@ -29,20 +32,24 @@ struct SnippetTreeView: View {
 
 private struct FolderSection: View {
     let folder: SnippetFolder
+    @Bindable var viewModel: SnippetTreeViewModel
     let onSnippetCopy: (Snippet) -> Void
     var onSnippetEdit: ((Snippet) -> Void)?
+    var forceExpanded: Bool = false
+
+    private var isExpanded: Bool {
+        forceExpanded || viewModel.isExpanded(folder)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             FolderRowView(
                 folder: folder,
-                isExpanded: Binding(
-                    get: { folder.isExpanded },
-                    set: { folder.isExpanded = $0 }
-                )
+                isExpanded: isExpanded,
+                onToggle: { viewModel.toggleExpanded(folder) }
             )
 
-            if folder.isExpanded {
+            if isExpanded {
                 ForEach(folder.snippets) { snippet in
                     SnippetRowView(
                         snippet: snippet,
@@ -54,8 +61,10 @@ private struct FolderSection: View {
                 ForEach(folder.children) { child in
                     FolderSection(
                         folder: child,
+                        viewModel: viewModel,
                         onSnippetCopy: onSnippetCopy,
-                        onSnippetEdit: onSnippetEdit
+                        onSnippetEdit: onSnippetEdit,
+                        forceExpanded: forceExpanded
                     )
                     .padding(.leading, 20)
                 }
@@ -92,6 +101,7 @@ private struct FolderSection: View {
 
     return SnippetTreeView(
         folder: folder,
+        viewModel: SnippetTreeViewModel(),
         onSnippetCopy: { snippet in
             print("Copy: \(snippet.shortcut)")
         },


### PR DESCRIPTION
## Summary
- Convert SnippetFolder from `@Observable class` to pure `struct`
- Remove `parent` reference (unused complexity)
- Move `isExpanded` UI state to `SnippetTreeViewModel.expandedFolderIDs`
- Add `isExpanded()` and `toggleExpanded()` methods to ViewModel
- Update views to use ViewModel for expansion state
- Auto-expand all folders when search is active

This reduces complexity by:
- Removing reference semantics where value semantics work
- Separating UI state from data model
- Eliminating unused parent back-references

## Test plan
- [ ] Build succeeds
- [ ] App launches and displays folder tree
- [ ] Folder expand/collapse works correctly
- [ ] Search expands all folders to show results

Closes #52