### PR TITLE
[REFACTOR] Remove duplicate keyboard shortcuts (#57)

### DIFF
--- a/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
+++ b/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
@@ -106,10 +106,8 @@ struct MenuBarContentView: View {
     private var actionBar: some View {
         HStack(spacing: 12) {
             Menu {
-                Button("New Snippet") { showingNewSnippetSheet = true }
-                    .keyboardShortcut("n", modifiers: .command)
-                Button("New Folder") { showingNewFolderSheet = true }
-                    .keyboardShortcut("n", modifiers: [.command, .shift])
+                Button("New Snippet (⌘N)") { showingNewSnippetSheet = true }
+                Button("New Folder (⇧⌘N)") { showingNewFolderSheet = true }
             } label: {
                 Label("New", systemImage: "plus")
             }


### PR DESCRIPTION
## Summary
- Remove redundant `.keyboardShortcut` modifiers from Menu items
- Add shortcut hints to menu item labels instead
- The hidden buttons in `keyboardShortcuts` view are the working shortcuts

## Test plan
- [ ] Build succeeds
- [ ] Cmd+N opens New Snippet dialog
- [ ] Cmd+Shift+N opens New Folder dialog
- [ ] Menu still shows shortcuts in labels

Closes #57