### PR TITLE
SOLID cleanup round 2: DRY paths, SRP imports, caseless enum

### DIFF
--- a/QuickSnip/QuickSnip/Services/ImportExportService.swift
+++ b/QuickSnip/QuickSnip/Services/ImportExportService.swift
@@ -4,9 +4,8 @@ struct ImportExportService {
     private let fileManager = FileManager.default
     private let snippetsDirectory: URL
 
-    init() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        snippetsDirectory = home.appendingPathComponent(".snippets", isDirectory: true)
+    init(snippetsDirectory: URL = SnippetFileService.defaultSnippetsDirectory) {
+        self.snippetsDirectory = snippetsDirectory
     }
 
     func exportToZip(folder: SnippetFolder, destination: URL) throws {

--- a/QuickSnip/QuickSnip/Services/MarkdownParser.swift
+++ b/QuickSnip/QuickSnip/Services/MarkdownParser.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct MarkdownParser {
+enum MarkdownParser {
     struct ParsedSnippet {
         let shortcut: String
         let content: String

--- a/QuickSnip/QuickSnip/Services/SnippetFileService.swift
+++ b/QuickSnip/QuickSnip/Services/SnippetFileService.swift
@@ -1,16 +1,19 @@
 import Foundation
 
 struct SnippetFileService: SnippetFileServiceProtocol {
+    static let defaultSnippetsDirectory: URL = {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".snippets", isDirectory: true)
+    }()
+
     let snippetsDirectory: URL
 
     private var fileManager: FileManager { FileManager.default }
 
-    init() {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        self.snippetsDirectory = home.appendingPathComponent(".snippets", isDirectory: true)
+    init(snippetsDirectory: URL = defaultSnippetsDirectory) {
+        self.snippetsDirectory = snippetsDirectory
     }
 
-    func ensureSnippetsDirectoryExists() throws {
+    private func ensureSnippetsDirectoryExists() throws {
         if !fileManager.fileExists(atPath: snippetsDirectory.path) {
             try fileManager.createDirectory(at: snippetsDirectory, withIntermediateDirectories: true)
         }

--- a/QuickSnip/QuickSnip/ViewModels/SettingsViewModel.swift
+++ b/QuickSnip/QuickSnip/ViewModels/SettingsViewModel.swift
@@ -19,8 +19,7 @@ final class SettingsViewModel {
     }
 
     var snippetsDirectory: URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".snippets", isDirectory: true)
+        SnippetFileService.defaultSnippetsDirectory
     }
 
     private enum Keys {

--- a/QuickSnip/QuickSnip/ViewModels/SnippetTreeViewModel.swift
+++ b/QuickSnip/QuickSnip/ViewModels/SnippetTreeViewModel.swift
@@ -109,6 +109,30 @@ final class SnippetTreeViewModel {
         NSWorkspace.shared.open(fileService.snippetsDirectory)
     }
 
+    func handleImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            let importService = ImportExportService()
+            do {
+                let importResult: ImportResult
+                if url.pathExtension == "zip" {
+                    importResult = try importService.importFromZip(url)
+                } else {
+                    importResult = try importService.importFolder(url)
+                }
+                loadSnippets()
+                notificationService.showImportSuccess(count: importResult.imported)
+            } catch {
+                errorMessage = error.localizedDescription
+                notificationService.showError(title: "Import Failed", message: error.localizedDescription)
+            }
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+            notificationService.showError(title: "Import Failed", message: error.localizedDescription)
+        }
+    }
+
     func openFullDiskAccessSettings() {
         textReplacementService.openFullDiskAccessSettings()
     }

--- a/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
+++ b/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
@@ -68,7 +68,7 @@ struct MenuBarContentView: View {
             allowedContentTypes: [.zip, .folder],
             allowsMultipleSelection: false
         ) { result in
-            handleImport(result)
+            viewModel.handleImport(result)
         }
         .fileExporter(
             isPresented: $showingExportPicker,
@@ -151,30 +151,6 @@ struct MenuBarContentView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
-    }
-
-    private func handleImport(_ result: Result<[URL], Error>) {
-        switch result {
-        case .success(let urls):
-            guard let url = urls.first else { return }
-            let importService = ImportExportService()
-            do {
-                let importResult: ImportResult
-                if url.pathExtension == "zip" {
-                    importResult = try importService.importFromZip(url)
-                } else {
-                    importResult = try importService.importFolder(url)
-                }
-                viewModel.loadSnippets()
-                NotificationService.shared.showImportSuccess(count: importResult.imported)
-            } catch {
-                viewModel.errorMessage = error.localizedDescription
-                NotificationService.shared.showError(title: "Import Failed", message: error.localizedDescription)
-            }
-        case .failure(let error):
-            viewModel.errorMessage = error.localizedDescription
-            NotificationService.shared.showError(title: "Import Failed", message: error.localizedDescription)
-        }
     }
 
     private func errorBanner(_ message: String) -> some View {

--- a/QuickSnip/QuickSnipTests/SnippetTreeViewModelTests.swift
+++ b/QuickSnip/QuickSnipTests/SnippetTreeViewModelTests.swift
@@ -338,4 +338,151 @@ final class SnippetTreeViewModelTests: XCTestCase {
 
         XCTAssertNotNil(viewModel.errorMessage)
     }
+
+    // MARK: - Delete Snippet Tests
+
+    func test_deleteSnippet_reloadsSnippets() {
+        var mockFileService = MockFileService()
+        mockFileService.snippetTreeToReturn = SnippetFolder(
+            name: "root",
+            path: URL(fileURLWithPath: "/tmp"),
+            snippets: [
+                Snippet(shortcut: ";test", content: "content", filePath: URL(fileURLWithPath: "/tmp/test.md"))
+            ]
+        )
+
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+        viewModel.loadSnippets()
+
+        guard let snippet = viewModel.rootFolder?.snippets.first else {
+            XCTFail("Snippet should exist")
+            return
+        }
+
+        viewModel.deleteSnippet(snippet)
+
+        // After deleting, loadSnippets is called again
+        XCTAssertNotNil(viewModel.rootFolder)
+    }
+
+    func test_deleteSnippet_setsErrorOnFailure() {
+        var mockFileService = MockFileService()
+        mockFileService.snippetTreeToReturn = SnippetFolder(
+            name: "root",
+            path: URL(fileURLWithPath: "/tmp"),
+            snippets: [
+                Snippet(shortcut: ";test", content: "content", filePath: URL(fileURLWithPath: "/tmp/test.md"))
+            ]
+        )
+        mockFileService.deleteError = TestError.testFailure
+
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+        viewModel.loadSnippets()
+
+        guard let snippet = viewModel.rootFolder?.snippets.first else {
+            XCTFail("Snippet should exist")
+            return
+        }
+
+        viewModel.deleteSnippet(snippet)
+
+        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertEqual(viewModel.errorMessage, "Test failure")
+    }
+
+    // MARK: - Delete Folder Tests
+
+    func test_deleteFolder_reloadsSnippets() {
+        let childFolder = SnippetFolder(name: "child", path: URL(fileURLWithPath: "/tmp/child"))
+        var mockFileService = MockFileService()
+        mockFileService.snippetTreeToReturn = SnippetFolder(
+            name: "root",
+            path: URL(fileURLWithPath: "/tmp"),
+            children: [childFolder]
+        )
+
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+        viewModel.loadSnippets()
+
+        viewModel.deleteFolder(childFolder)
+
+        // After deleting, loadSnippets is called again
+        XCTAssertNotNil(viewModel.rootFolder)
+    }
+
+    func test_deleteFolder_setsErrorOnFailure() {
+        let childFolder = SnippetFolder(name: "child", path: URL(fileURLWithPath: "/tmp/child"))
+        var mockFileService = MockFileService()
+        mockFileService.snippetTreeToReturn = SnippetFolder(
+            name: "root",
+            path: URL(fileURLWithPath: "/tmp"),
+            children: [childFolder]
+        )
+        mockFileService.deleteError = TestError.testFailure
+
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+        viewModel.loadSnippets()
+
+        viewModel.deleteFolder(childFolder)
+
+        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertEqual(viewModel.errorMessage, "Test failure")
+    }
+
+    // MARK: - Copy to Clipboard Tests
+
+    func test_copyToClipboard_copiesContentToPasteboard() {
+        let mockFileService = MockFileService()
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+
+        let snippet = Snippet(
+            shortcut: ";test",
+            content: "Hello World",
+            filePath: URL(fileURLWithPath: "/tmp/test.md")
+        )
+
+        viewModel.copyToClipboard(snippet)
+
+        let pasteboardContent = NSPasteboard.general.string(forType: .string)
+        XCTAssertEqual(pasteboardContent, "Hello World")
+    }
+
+    func test_copyToClipboard_expandsVariables() {
+        let mockFileService = MockFileService()
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+
+        let snippet = Snippet(
+            shortcut: ";test",
+            content: "Today is {date}",
+            filePath: URL(fileURLWithPath: "/tmp/test.md")
+        )
+
+        viewModel.copyToClipboard(snippet)
+
+        let pasteboardContent = NSPasteboard.general.string(forType: .string)
+        XCTAssertNotNil(pasteboardContent)
+        XCTAssertFalse(pasteboardContent!.contains("{date}"))
+    }
+
+    // MARK: - Handle Import Tests
+
+    func test_handleImport_setsErrorOnFailure() {
+        let mockFileService = MockFileService()
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+
+        let testError = NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Import error"])
+        viewModel.handleImport(.failure(testError))
+
+        XCTAssertEqual(viewModel.errorMessage, "Import error")
+    }
+
+    func test_handleImport_ignoresEmptyURLArray() {
+        let mockFileService = MockFileService()
+        let viewModel = SnippetTreeViewModel(fileService: mockFileService)
+        viewModel.errorMessage = nil
+
+        viewModel.handleImport(.success([]))
+
+        XCTAssertNil(viewModel.errorMessage)
+    }
 }


### PR DESCRIPTION
## Summary

- Refactor MarkdownParser from struct to caseless enum (Swift idiom)
- Extract snippets path constant to single source of truth in SnippetFileService
- Move import handling from MenuBarContentView to SnippetTreeViewModel (SRP)
- Add comprehensive tests for delete, copy, and import operations

## Changes

### MarkdownParser
Convert to caseless enum to prevent accidental instantiation of utility type.

### Path constant extraction
`SnippetFileService.defaultSnippetsDirectory` is now the single source of truth.
ImportExportService and SettingsViewModel use this constant instead of duplicating the path logic.

### Import handling moved to ViewModel
View now delegates all business logic to ViewModel following Single Responsibility Principle.
Removes 22 LOC from MenuBarContentView.

### New tests
- `test_deleteSnippet_reloadsSnippets`
- `test_deleteSnippet_setsErrorOnFailure`
- `test_deleteFolder_reloadsSnippets`
- `test_deleteFolder_setsErrorOnFailure`
- `test_copyToClipboard_copiesContentToPasteboard`
- `test_copyToClipboard_expandsVariables`
- `test_handleImport_setsErrorOnFailure`
- `test_handleImport_ignoresEmptyURLArray`

## Test plan
- [x] All 91 tests pass
- [x] Build succeeds