### PR TITLE
Fix Text Replacement sync by adding UUID and CloudKit flags

### DIFF
--- a/QuickSnip/QuickSnip/Services/SQLiteDatabase.swift
+++ b/QuickSnip/QuickSnip/Services/SQLiteDatabase.swift
@@ -142,6 +142,16 @@ final class SQLiteDatabase {
         return firstValue as? T
     }
 
+    func checkpoint() throws {
+        guard let database = db else {
+            throw SQLiteError.notOpen
+        }
+        let result = sqlite3_wal_checkpoint_v2(database, nil, SQLITE_CHECKPOINT_PASSIVE, nil, nil)
+        if result != SQLITE_OK && result != SQLITE_BUSY {
+            throw SQLiteError.executeFailed("Checkpoint failed: \(errorMessage)")
+        }
+    }
+
     private var errorMessage: String {
         if let error = sqlite3_errmsg(db) {
             return String(cString: error)

--- a/QuickSnip/QuickSnip/Services/TextReplacementService.swift
+++ b/QuickSnip/QuickSnip/Services/TextReplacementService.swift
@@ -14,11 +14,15 @@ struct TextReplacementService: TextReplacementServiceProtocol {
     }()
 
     var hasAccess: Bool {
-        guard let fileHandle = try? FileHandle(forWritingTo: Self.databaseURL) else {
+        let testURL = Self.databaseURL.deletingLastPathComponent()
+            .appendingPathComponent(".quicksnip_fda_test")
+        do {
+            try "test".write(to: testURL, atomically: true, encoding: .utf8)
+            try FileManager.default.removeItem(at: testURL)
+            return true
+        } catch {
             return false
         }
-        try? fileHandle.close()
-        return true
     }
 
     func getCurrentReplacements() throws -> [TextReplacement] {
@@ -50,6 +54,9 @@ struct TextReplacementService: TextReplacementServiceProtocol {
 
         var inserted = 0
         var updated = 0
+        var maxPK: Int64 = try db.queryScalar(
+            "SELECT MAX(Z_PK) FROM ZTEXTREPLACEMENTENTRY"
+        ) ?? 0
 
         for snippet in snippets where snippet.enabled {
             let phrase = snippet.content
@@ -58,25 +65,32 @@ struct TextReplacementService: TextReplacementServiceProtocol {
             if existingShortcuts.contains(shortcut) {
                 try db.execute("""
                     UPDATE ZTEXTREPLACEMENTENTRY
-                    SET ZPHRASE = ?, ZTIMESTAMP = ?
+                    SET ZPHRASE = ?, ZTIMESTAMP = ?, ZNEEDSSAVETOCLOUD = 1
                     WHERE ZSHORTCUT = ?
                 """, parameters: [phrase, currentTimestamp(), shortcut])
                 updated += 1
             } else {
-                let maxZ: Int64 = try db.queryScalar("""
-                    SELECT MAX(Z_PK) FROM ZTEXTREPLACEMENTENTRY
-                """) ?? 0
-
+                maxPK += 1
+                let uniqueName = UUID().uuidString
                 try db.execute("""
                     INSERT INTO ZTEXTREPLACEMENTENTRY
-                    (Z_PK, Z_ENT, Z_OPT, ZSHORTCUT, ZPHRASE, ZTIMESTAMP, ZWASDELETED)
-                    VALUES (?, 1, 1, ?, ?, ?, 0)
-                """, parameters: [maxZ + 1, shortcut, phrase, currentTimestamp()])
+                    (Z_PK, Z_ENT, Z_OPT, ZNEEDSSAVETOCLOUD, ZWASDELETED,
+                     ZTIMESTAMP, ZPHRASE, ZSHORTCUT, ZUNIQUENAME)
+                    VALUES (?, 1, 1, 1, 0, ?, ?, ?, ?)
+                """, parameters: [maxPK, currentTimestamp(), phrase, shortcut, uniqueName])
                 inserted += 1
             }
         }
 
+        if inserted > 0 {
+            try db.execute("""
+                UPDATE Z_PRIMARYKEY SET Z_MAX = ? WHERE Z_NAME = 'TextReplacementEntry'
+            """, parameters: [maxPK])
+        }
+
+        try db.checkpoint()
         touchDatabase()
+        restartKeyboardService()
 
         return SyncResult(inserted: inserted, updated: updated)
     }
@@ -95,6 +109,13 @@ struct TextReplacementService: TextReplacementServiceProtocol {
             [.modificationDate: Date()],
             ofItemAtPath: Self.databaseURL.path
         )
+    }
+
+    private func restartKeyboardService() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+        task.arguments = ["keyboardservicesd"]
+        try? task.run()
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix Text Replacement sync which was failing silently
- Add proper CloudKit-compatible database entries
- Restart keyboardservicesd daemon to apply changes immediately

## Root Cause

Database entries created by QuickSnip were missing critical fields required by macOS:

| Field | Was | Should Be |
|-------|-----|-----------|
| ZUNIQUENAME | NULL | UUID string |
| ZNEEDSSAVETOCLOUD | NULL | 1 (for pending sync) |
| Z_PRIMARYKEY.Z_MAX | Not updated | Current max PK |

## Changes

1. **SQLiteDatabase.swift**: Add `checkpoint()` method for WAL persistence
2. **TextReplacementService.swift**:
   - Fix `hasAccess` to test write access in KeyboardServices directory
   - Add `ZUNIQUENAME` (UUID) to INSERT statements
   - Add `ZNEEDSSAVETOCLOUD = 1` to INSERT and UPDATE statements
   - Update `Z_PRIMARYKEY.Z_MAX` after inserts
   - Add `restartKeyboardService()` to reload daemon via `killall keyboardservicesd`

## Test plan

- [x] Build succeeds
- [x] All 50 tests pass
- [ ] Create new snippet and sync
- [ ] Verify entry appears in System Settings > Keyboard > Text Replacements
- [ ] Verify iCloud sync to iOS device

Closes #73