### PR TITLE
Add GlobalPreferences.plist update for immediate Text Replacement activation

### DIFF
--- a/QuickSnip/QuickSnip/Services/TextReplacementService.swift
+++ b/QuickSnip/QuickSnip/Services/TextReplacementService.swift
@@ -90,6 +90,7 @@ struct TextReplacementService: TextReplacementServiceProtocol {
 
         try db.checkpoint()
         touchDatabase()
+        updateGlobalPreferences(snippets)
         restartKeyboardService()
 
         return SyncResult(inserted: inserted, updated: updated)
@@ -116,6 +117,35 @@ struct TextReplacementService: TextReplacementServiceProtocol {
         task.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
         task.arguments = ["keyboardservicesd"]
         try? task.run()
+    }
+
+    private func updateGlobalPreferences(_ snippets: [Snippet]) {
+        let defaults = UserDefaults.standard
+        let key = "NSUserDictionaryReplacementItems"
+        var replacements = defaults.array(forKey: key) as? [[String: Any]] ?? []
+        let existingShortcuts = Set(replacements.compactMap { $0["replace"] as? String })
+
+        for snippet in snippets where snippet.enabled {
+            if existingShortcuts.contains(snippet.shortcut) {
+                // Update existing entry
+                if let index = replacements.firstIndex(where: { ($0["replace"] as? String) == snippet.shortcut }) {
+                    replacements[index] = [
+                        "on": 1,
+                        "replace": snippet.shortcut,
+                        "with": snippet.content
+                    ]
+                }
+            } else {
+                // Add new entry
+                replacements.append([
+                    "on": 1,
+                    "replace": snippet.shortcut,
+                    "with": snippet.content
+                ])
+            }
+        }
+
+        defaults.set(replacements, forKey: key)
     }
 }
 


### PR DESCRIPTION
## Summary

- Update GlobalPreferences.plist alongside TextReplacements.db
- Text replacements now work immediately after sync

## Context

macOS uses **two storage locations** for text replacements:

| Location | Purpose |
|----------|---------|
| `TextReplacements.db` | iCloud/CloudKit sync |
| `GlobalPreferences.plist` | Immediate local use |

PR #74 fixed the database sync but text replacements didn't activate until the system synced the plist.

## Changes

Added `updateGlobalPreferences()` method that:
- Reads current `NSUserDictionaryReplacementItems` from UserDefaults
- Updates existing entries or adds new ones
- Writes back to UserDefaults

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [ ] Create new snippet and sync
- [ ] Text replacement works immediately in any Cocoa app

Closes #75