### PR TITLE
Fix: Deleted snippets now removed from Text Replacement + version display

### DIFF
--- a/QuickSnip/QuickSnip/Protocols/ServiceProtocols.swift
+++ b/QuickSnip/QuickSnip/Protocols/ServiceProtocols.swift
@@ -18,5 +18,6 @@ protocol TextReplacementServiceProtocol: Sendable {
     var hasAccess: Bool { get }
 
     func syncSnippets(_ snippets: [Snippet]) throws -> SyncResult
+    func deleteReplacement(shortcut: String) throws
     func openFullDiskAccessSettings()
 }

--- a/QuickSnip/QuickSnip/Services/TextReplacementService.swift
+++ b/QuickSnip/QuickSnip/Services/TextReplacementService.swift
@@ -131,6 +131,25 @@ struct TextReplacementService: TextReplacementServiceProtocol {
         return SyncResult(inserted: inserted, updated: updated)
     }
 
+    func deleteReplacement(shortcut: String) throws {
+        let db = SQLiteDatabase(url: Self.databaseURL)
+        try db.open()
+        defer { db.close() }
+
+        // Mark as deleted in database for iCloud sync (soft delete / tombstone)
+        // ZWASDELETED = 1 triggers CloudKit to propagate deletion to other devices
+        try db.execute("""
+            UPDATE ZTEXTREPLACEMENTENTRY
+            SET ZWASDELETED = 1, ZNEEDSSAVETOCLOUD = 1, ZTIMESTAMP = ?
+            WHERE ZSHORTCUT = ?
+        """, parameters: [currentTimestamp(), shortcut])
+
+        try db.checkpoint()
+        touchDatabase()
+        removeFromGlobalPreferences(shortcut: shortcut)
+        restartKeyboardService()
+    }
+
     func openFullDiskAccessSettings() {
         let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")!
         NSWorkspace.shared.open(url)
@@ -182,6 +201,19 @@ struct TextReplacementService: TextReplacementServiceProtocol {
                 ])
             }
         }
+
+        globalDomain[key] = replacements
+        defaults.setPersistentDomain(globalDomain, forName: UserDefaults.globalDomain)
+    }
+
+    /// Removes a shortcut from GlobalPreferences.plist for immediate local deactivation.
+    private func removeFromGlobalPreferences(shortcut: String) {
+        let key = "NSUserDictionaryReplacementItems"
+        let defaults = UserDefaults.standard
+        var globalDomain = defaults.persistentDomain(forName: UserDefaults.globalDomain) ?? [:]
+        var replacements = globalDomain[key] as? [[String: Any]] ?? []
+
+        replacements.removeAll { ($0["replace"] as? String) == shortcut }
 
         globalDomain[key] = replacements
         defaults.setPersistentDomain(globalDomain, forName: UserDefaults.globalDomain)

--- a/QuickSnip/QuickSnip/ViewModels/SnippetTreeViewModel.swift
+++ b/QuickSnip/QuickSnip/ViewModels/SnippetTreeViewModel.swift
@@ -93,6 +93,9 @@ final class SnippetTreeViewModel {
 
     func deleteSnippet(_ snippet: Snippet) {
         perform {
+            // Remove from Text Replacement (DB + plist) for iCloud sync
+            try? textReplacementService.deleteReplacement(shortcut: snippet.shortcut)
+            // Delete the markdown file
             try fileService.deleteSnippet(snippet)
             loadSnippets()
         }
@@ -100,6 +103,11 @@ final class SnippetTreeViewModel {
 
     func deleteFolder(_ folder: SnippetFolder) {
         perform {
+            // Remove all snippets in folder from Text Replacement for iCloud sync
+            for snippet in folder.allSnippets {
+                try? textReplacementService.deleteReplacement(shortcut: snippet.shortcut)
+            }
+            // Delete the folder and all contents
             try fileService.deleteFolder(folder)
             loadSnippets()
         }

--- a/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
+++ b/QuickSnip/QuickSnip/Views/MenuBarContentView.swift
@@ -222,6 +222,10 @@ struct MenuBarContentView: View {
 
             Spacer()
 
+            Text("v\(appVersion)")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+
             SettingsLink {
                 Image(systemName: "gear")
             }
@@ -235,6 +239,10 @@ struct MenuBarContentView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
     }
 }
 

--- a/QuickSnip/QuickSnipTests/SettingsViewModelTests.swift
+++ b/QuickSnip/QuickSnipTests/SettingsViewModelTests.swift
@@ -146,6 +146,8 @@ private final class TrackingTextReplacementService: TextReplacementServiceProtoc
         SyncResult(inserted: 0, updated: 0)
     }
 
+    func deleteReplacement(shortcut: String) throws {}
+
     func openFullDiskAccessSettings() {
         onOpenSettings()
     }

--- a/QuickSnip/QuickSnipTests/SnippetTreeViewModelTests.swift
+++ b/QuickSnip/QuickSnipTests/SnippetTreeViewModelTests.swift
@@ -40,10 +40,15 @@ final class MockTextReplacementService: TextReplacementServiceProtocol, @uncheck
     var hasAccess: Bool = true
     var syncError: Error?
     var syncResult = SyncResult(inserted: 0, updated: 0)
+    var deletedShortcuts: [String] = []
 
     func syncSnippets(_ snippets: [Snippet]) throws -> SyncResult {
         if let error = syncError { throw error }
         return syncResult
+    }
+
+    func deleteReplacement(shortcut: String) throws {
+        deletedShortcuts.append(shortcut)
     }
 
     func openFullDiskAccessSettings() {}


### PR DESCRIPTION
## Summary
- Fix bug where deleted snippets remained in macOS System Settings Text Replacement
- Deleted entries are now properly synced to iOS via iCloud (using ZWASDELETED tombstone)
- Display app version in menubar footer

## Changes
- Add `deleteReplacement(shortcut:)` to TextReplacementServiceProtocol
- Set `ZWASDELETED = 1` and `ZNEEDSSAVETOCLOUD = 1` in database for iCloud sync
- Remove entry from GlobalPreferences.plist for immediate local deactivation
- Call deleteReplacement when deleting snippets or folders
- Show version (e.g. "v1.0.4") in footer next to gear icon

## Test Plan
- [ ] Delete a snippet in QuickSnip
- [ ] Verify it disappears from System Settings > Keyboard > Text Replacement
- [ ] Verify deletion syncs to iOS device
- [ ] Verify version is displayed in menubar footer

Closes #78